### PR TITLE
Implement DeviceSerialized to smoothly move data to host and back

### DIFF
--- a/dask_cuda/device_host_file.py
+++ b/dask_cuda/device_host_file.py
@@ -5,7 +5,7 @@ from distributed.protocol import (
     deserialize_bytes,
     serialize,
     serialize_bytelist,
-    Serialized,
+    register_generic,
 )
 from dask.sizeof import sizeof
 from distributed.utils import nbytes
@@ -29,15 +29,29 @@ if not hasattr(sizeof, "register_numba"):
             return int(x.nbytes)
 
 
-# Register sizeof for Serialized while Dask doesn't add it
-if not hasattr(sizeof, "register_serialized"):
+class DeviceSerialized:
+    """ Store device object on the host
 
-    @sizeof.register(Serialized)
-    def register_serialized(obj):
-        return sum(map(nbytes, obj.frames))
+    This stores a device-side object as
+
+    1.  A msgpack encodable header
+    2.  A list of objects that are returned by calling
+        `numba.cuda.as_cuda_array(f).copy_to_host()`
+        which are typically NumPy arrays
+    """
+
+    def __init__(self, header, parts):
+        self.header = header
+        self.parts = parts
+
+    def __sizeof__(self):
+        return sum(map(nbytes, self.parts))
 
 
-def device_to_host(obj: object) -> Serialized:
+register_generic(DeviceSerialized)
+
+
+def device_to_host(obj: object) -> DeviceSerialized:
     header, frames = serialize(obj, serializers=["cuda"])
     is_cuda = [hasattr(f, "__cuda_array_interface__") for f in frames]
     frames = [
@@ -45,43 +59,14 @@ def device_to_host(obj: object) -> Serialized:
         for ic, f in zip(is_cuda, frames)
     ]
     header = {"sub-header": header, "is-cuda": is_cuda}
-    return Serialized(header, frames)
+    return DeviceSerialized(header, frames)
 
 
-def host_to_device(s: Serialized) -> object:
+def host_to_device(s: DeviceSerialized) -> object:
     is_cuda = s.header["is-cuda"]
     header = s.header["sub-header"]
-    frames = [cuda.to_device(f) if ic else f for ic, f in zip(is_cuda, s.frames)]
+    frames = [cuda.to_device(f) if ic else f for ic, f in zip(is_cuda, s.parts)]
     return deserialize(header, frames)
-
-
-def _serialize_if_device(obj):
-    if is_device_object(obj):
-        return device_to_host(obj)
-    else:
-        return obj
-
-
-def _deserialize_if_device(obj):
-    if isinstance(obj, Serialized):
-        return host_to_device(obj)
-    else:
-        return obj
-
-
-def _serialize_bytelist(obj):
-    if isinstance(obj, Serialized):
-        obj = serialize(obj)
-    return serialize_bytelist(obj)
-
-
-def _deserialize_bytes(b):
-    obj = deserialize_bytes(b)
-    if isinstance(obj, tuple) and len(obj) == 2:
-        header, frames = obj
-        if isinstance(header, dict) and "sub-header" in header:
-            return Serialized(header, frames)
-    return obj
 
 
 class DeviceHostFile(ZictBase):
@@ -111,17 +96,14 @@ class DeviceHostFile(ZictBase):
         path = os.path.join(local_dir, "storage")
 
         self.host_func = dict()
-        self.disk_func = Func(
-            _serialize_bytelist, _deserialize_bytes, File(path)
-        )
+        self.disk_func = Func(serialize_bytelist, deserialize_bytes, File(path))
         self.host_buffer = Buffer(
             self.host_func, self.disk_func, memory_limit, weight=weight
         )
 
+        self.device_keys = set()
         self.device_func = dict()
-        self.device_host_func = Func(
-            _serialize_if_device, _deserialize_if_device, self.host_buffer
-        )
+        self.device_host_func = Func(device_to_host, host_to_device, self.host_buffer)
         self.device_buffer = Buffer(
             self.device_func, self.device_host_func, device_memory_limit, weight=weight
         )
@@ -135,23 +117,18 @@ class DeviceHostFile(ZictBase):
 
     def __setitem__(self, key, value):
         if is_device_object(value):
+            self.device_keys.add(key)
             self.device_buffer[key] = value
         else:
             self.host_buffer[key] = value
 
     def __getitem__(self, key):
-        if key in self.host_buffer:
-            obj = self.host_buffer[key]
-            if isinstance(obj, Serialized):
-                del self.host_buffer[key]
-                self.device_buffer[key] = host_to_device(obj)
-            else:
-                return obj
-
-        if key in self.device_buffer:
+        if key in self.device_keys:
             return self.device_buffer[key]
+        elif key in self.host_buffer:
+            return self.host_buffer[key]
         else:
-            raise KeyError
+            raise KeyError(key)
 
     def __len__(self):
         return len(self.device_buffer)
@@ -159,5 +136,6 @@ class DeviceHostFile(ZictBase):
     def __iter__(self):
         return iter(self.device_buffer)
 
-    def __delitem__(self, i):
-        del self.device_buffer[i]
+    def __delitem__(self, key):
+        self.device_keys.discard(key)
+        del self.device_buffer[key]

--- a/dask_cuda/tests/test_device_host_file.py
+++ b/dask_cuda/tests/test_device_host_file.py
@@ -1,10 +1,10 @@
 import numpy as np
 import cupy
-from dask_cuda.device_host_file import DeviceHostFile
+from dask_cuda.device_host_file import DeviceHostFile, host_to_device, device_to_host
 from random import randint
+import dask.array as da
 
 import pytest
-from cupy.testing import assert_array_equal
 
 
 @pytest.mark.parametrize("num_host_arrays", [1, 10, 100])
@@ -33,14 +33,15 @@ def test_device_host_file_short(
     full = host + device
     random.shuffle(full)
 
-    for i in full:
-        dhf[i[0]] = i[1]
+    for k, v in full:
+        dhf[k] = v
 
     random.shuffle(full)
 
-    for i in full:
-        assert_array_equal(i[1], dhf[i[0]])
-        del dhf[i[0]]
+    for k, original in full:
+        acquired = dhf[k]
+        da.assert_eq(original, acquired)
+        del dhf[k]
 
     assert set(dhf.device.keys()) == set()
     assert set(dhf.host.keys()) == set()
@@ -94,19 +95,40 @@ def test_device_host_file_step_by_step(tmp_path):
     assert set(dhf.host.keys()) == set(["a2", "b2"])
     assert set(dhf.disk.keys()) == set(["a1", "b1"])
 
-    assert_array_equal(dhf["a1"], a)
+    da.assert_eq(dhf["a1"], a)
     del dhf["a1"]
-    assert_array_equal(dhf["a2"], a)
+    da.assert_eq(dhf["a2"], a)
     del dhf["a2"]
-    assert_array_equal(dhf["b1"], b)
+    da.assert_eq(dhf["b1"], b)
     del dhf["b1"]
-    assert_array_equal(dhf["b2"], b)
+    da.assert_eq(dhf["b2"], b)
     del dhf["b2"]
-    assert_array_equal(dhf["b3"], b)
+    da.assert_eq(dhf["b3"], b)
     del dhf["b3"]
-    assert_array_equal(dhf["b4"], b)
+    da.assert_eq(dhf["b4"], b)
     del dhf["b4"]
 
     assert set(dhf.device.keys()) == set()
     assert set(dhf.host.keys()) == set()
     assert set(dhf.disk.keys()) == set()
+
+
+def test_serialize_cupy():
+    x = cupy.arange(10)
+    obj = device_to_host(x)
+    assert all(isinstance(part, (bytes, memoryview, np.ndarray)) for part in obj.parts)
+    y = host_to_device(obj)
+
+    da.assert_eq(x, y)
+
+
+def test_serialize_cudf():
+    cudf = pytest.importorskip("cudf")
+    dd = pytest.importorskip("dask.dataframe")
+
+    df = cudf.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]})
+    obj = device_to_host(df)
+    assert all(isinstance(part, (bytes, memoryview, np.ndarray)) for part in obj.parts)
+    df2 = host_to_device(obj)
+
+    dd.assert_eq(df, df2)


### PR DESCRIPTION
So some issues I ran into:

It looks like even though we never put host-like things into `self.device_buffer` they can still appear to be there because that object looks at it's `.slow` attribute, which is `self.host_buffer`.  So when we put something into `self.host_buffer` it can appear to also be in `self.device_buffer`.  To address this I've taken the somewhat kludgy (though also direct) approach of maintaining a separate set of all the things we've placed into or removed from `self.device_buffer`.  This seems to do the trick, and I think it simplifies more than it harms.

I also ran into issues with reading and writing the "frames" that we were getting from `numba.cuda.as_gpu_array(...).copy_to_host()`.  This was creating numpy arrays rather than proper byte-like objects.  We were then writing these numpy arrays to disk without recording their metadata, which resulted in a loss of information.  I've invoked a generic serialization solution for `DeviceSerialized` which should traverse through its attributes and handle things sensibly.  We could improve this a bit by choosing to traverse only through the `.parts/frames` attribute, but I'll leave that for future work.

I've also renamed the `.frames` attribute to `.parts` to signal that what we're storing here in this attribute is more complex than just bytestrings.